### PR TITLE
Update library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -5,7 +5,7 @@
   "repository":
   {
     "type": "git",
-    "url": "https://github.com/ToPitz/IRLib2.git"
+    "url": "https://github.com/cyborg5/IRLib2.git"
   },
   "authors":
   [
@@ -20,8 +20,8 @@
       "url": "http://www.righto.com/2009/08/multi-protocol-infrared-remote-library.html"
     }
   ],
-  "dependencies":
-  {
+  "export": {
+    "include": "IRLib2"
   },
   "version": "2.0.0",
   "frameworks": "arduino",


### PR DESCRIPTION
I don't know what to do with this manifest. It is wrong and people can't use it. See https://community.platformio.org/t/problem-with-build-irlib2/2231

1. The repository contains multiple libraries where original author writes about that.
2. Current manifest points to ROOT of a repository which means to build ALL SOURCE FILES.

What I propose?

1. `library.json` should be added to each library/folder with "relative" source pointer using `export.include` field. See docs http://docs.platformio.org/en/latest/librarymanager/config.html#export
2. We have similar repository wuth multiple libraries. See its manifests: https://github.com/jrowberg/i2cdevlib/tree/master/Arduino

------

Finally, I would recommend to make PR directly to original repository and register its manfiests.

Thanks!